### PR TITLE
chore(refactor): reorganize commands for clearer groupings

### DIFF
--- a/env/ansible.go
+++ b/env/ansible.go
@@ -57,11 +57,11 @@ func GetEnvFromAnsibleVault(c *cli.Context) (string, error) {
 func retrieveVaultPassword(vaultPasswordFile string) (string, error) {
 	if vaultPasswordFile != "" {
 		if _, err := os.Stat(vaultPasswordFile); os.IsNotExist(err) {
-			return "", errors.New("ERROR: vault-password-file, could not find: " + vaultPasswordFile)
+			return "", fmt.Errorf("ERROR: vault-password-file, could not find: %s", vaultPasswordFile)
 		}
 		pw, err := ioutil.ReadFile(vaultPasswordFile)
 		if err != nil {
-			return "", errors.New("ERROR: vault-password-file, " + err.Error())
+			return "", err
 		}
 		return strings.TrimSpace(string(pw)), nil
 	}

--- a/main.go
+++ b/main.go
@@ -368,13 +368,13 @@ func main() {
 									&cli.StringFlag{
 										Name:     "filter-prefix",
 										Aliases:  []string{"f"},
-										Usage:    "List of prefixes (csv) used to filter values from display. Set to \"\" to remove any filters.",
+										Usage:    "List of prefixes (csv) used to filter values from display. Set to `\"\"` to remove any filters.",
 										Required: false,
 										Value:    "npm_,KUBERNETES_,API_PORT",
 									},
 									&cli.StringFlag{
 										Name:     "exclude",
-										Usage:    "List (csv) of specific env vars to exclude values from display. Set to \"\" to remove any exclusions.",
+										Usage:    "List (csv) of specific env vars to exclude values from display. Set to `\"\"` to remove any exclusions.",
 										Required: false,
 										Value:    "PATH,SHLVL,HOSTNAME",
 									},

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 					{
 						// describe-secret
 						Name:  "describe",
-						Usage: "print description of secret to STDOUT",
+						Usage: "print description of secret to `STDOUT`",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:    "secret-id",
@@ -231,13 +231,13 @@ func main() {
 									&cli.StringFlag{
 										Name:     "filter-prefix",
 										Aliases:  []string{"f"},
-										Usage:    "List of prefixes (csv) used to filter values from display. Set to \"\" to remove any filters.",
+										Usage:    "List of prefixes (csv) used to filter values from display. Set to `\"\"` to remove any filters.",
 										Required: false,
 										Value:    "npm_,KUBERNETES_,API_PORT",
 									},
 									&cli.StringFlag{
 										Name:     "exclude",
-										Usage:    "List (csv) of specific env vars to exclude values from display. Set to \"\" to remove any exclusions.",
+										Usage:    "List (csv) of specific env vars to exclude values from display. Set to `\"\"` to remove any exclusions.",
 										Required: false,
 										Value:    "PATH,SHLVL,HOSTNAME",
 									},
@@ -280,7 +280,7 @@ func main() {
 									},
 									&cli.StringFlag{
 										Name:     "dotenv",
-										Usage:    "Path to .env file on Pod",
+										Usage:    "Path to `.env` file on Pod",
 										Required: false,
 										Value:    "$PWD/.env",
 									},

--- a/main.go
+++ b/main.go
@@ -188,17 +188,14 @@ func main() {
 				},
 			},
 			{
-				Name: "env",
+				Name:    "env",
 				Aliases: []string{"e"},
-				Usage: "Commands to interact with environment variables, both local and on cluster.",
-				// TODO: add UsageText
-				UsageText: "TODO",
+				Usage:   "Commands to interact with environment variables, both local and on cluster.",
 				Subcommands: []*cli.Command{
 					{
-						Name:      "diff",
-						Aliases:   []string{"d"},
-						Usage: "Print out detailed diff reports comparing local and running Pod",
-						// TODO: add UsageText
+						Name:    "diff",
+						Aliases: []string{"d"},
+						Usage:   "Print out detailed diff reports comparing local and running Pod",
 						Subcommands: []*cli.Command{
 							{
 								Name:      "namespace",
@@ -293,15 +290,14 @@ func main() {
 						},
 					},
 					{
-						Name:      "view",
-						Aliases:   []string{"v"},
+						Name:    "view",
+						Aliases: []string{"v"},
 						Usage:   "View configured environment for either local or running on a Pod",
-						// TODO: add UsageText
 						Subcommands: []*cli.Command{
 							{
 								Name:      "configmap",
 								Aliases:   []string{"c"},
-								Usage:     "View values based on local settings",
+								Usage:     "View env values based on local settings in a ConfigMap and secrets.yml",
 								UsageText: info.ViewLocalCommandHelpText,
 								Flags: []cli.Flag{
 									&cli.StringFlag{
@@ -328,7 +324,7 @@ func main() {
 							{
 								Name:      "ansible",
 								Aliases:   []string{"legacy"},
-								Usage:     "View value from ansible-vault encrypted Kube Secret file.",
+								Usage:     "View env values from ansible-vault encrypted Secret file.",
 								UsageText: info.ViewAnsibleEncryptedEnvCommandHelpText,
 								Flags: []cli.Flag{
 									&cli.StringFlag{
@@ -402,8 +398,8 @@ func main() {
 				},
 			},
 			{
-				Name:   "install-manpage",
-				Usage:  "Generate and install man page",
+				Name:  "install-manpage",
+				Usage: "Generate and install man page",
 				Action: func(c *cli.Context) error {
 					mp, _ := info.ToMan(c.App)
 					err := ioutil.WriteFile("/usr/local/share/man/man8/gwsm.8", []byte(mp), 0644)

--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ func main() {
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
 			{
-				Name:    "secretsmanager",
-				Aliases: []string{"sm"},
+				Name:    "sm",
+				Aliases: []string{"secretsmanager"},
 				Usage:   "Secrets Manager commands w/ interactive interface",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{
@@ -83,6 +83,7 @@ func main() {
 						Name:    "edit",
 						Aliases: []string{"e"},
 						Usage:   "interactive edit of a secret String Value",
+						// TODO: add UsageText
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:    "secret-id",
@@ -97,6 +98,7 @@ func main() {
 						Name:    "create",
 						Aliases: []string{"c"},
 						Usage:   "create new secret in Secrets Manager",
+						// TODO: add UsageText
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "secret-id",
@@ -186,193 +188,204 @@ func main() {
 				},
 			},
 			{
-				Name:      "diff",
-				Aliases:   []string{"d"},
-				Usage:     "View diff of local vs. namespace",
-				UsageText: info.ViewDiffCommandHelpText,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "secrets",
-						Aliases:  []string{"s"},
-						Usage:    "Path to secrets.yml",
-						Required: false,
-						Value:    ".docker/secrets.yml",
-					},
-					&cli.StringFlag{
-						Name:     "configmap",
-						Aliases:  []string{"c"},
-						Usage:    "Path to configmap.yaml",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:     "namespace",
-						Aliases:  []string{"n"},
-						Usage:    "Kube Namespace list Pods from",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:     "cmd",
-						Usage:    "Command to inspect",
-						Required: false,
-						Value:    "node",
-					},
-					&cli.StringFlag{
-						Name:     "filter-prefix",
-						Aliases:  []string{"f"},
-						Usage:    "List of prefixes (csv) used to filter values from display. Set to \"\" to remove any filters.",
-						Required: false,
-						Value:    "npm_,KUBERNETES_,API_PORT",
-					},
-					&cli.StringFlag{
-						Name:     "exclude",
-						Usage:    "List (csv) of specific env vars to exclude values from display. Set to \"\" to remove any exclusions.",
-						Required: false,
-						Value:    "PATH,SHLVL,HOSTNAME",
-					},
-					&cli.StringFlag{
-						Name:  "secret-suffix",
-						Usage: "Suffix used to find ENV variables that denote the Secret Manager Secrets to lookup",
-						Value: "_NAME",
-					},
-				},
-				Action: cmd.ViewEnvDiff,
-			},
-			{
-				Name:      "diff:legacy",
-				Aliases:   []string{"diff:ansible"},
-				Usage:     "View diff of local (ansible encrypted) vs. namespace",
-				UsageText: info.ViewAnsibleEnvDiffCommandHelpText,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     "vault-password-file",
-						Usage:    "vault password file `VAULT_PASSWORD_FILE`",
-						Required: false,
-					},
-					&cli.StringFlag{
-						Name:     "encrypted-env-file",
-						Aliases:  []string{"e"},
-						Usage:    "Path to encrypted Kube Secret file",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:    "accessor",
-						Aliases: []string{"a"},
-						Usage:   "Accessor key to pull data out of Data block.",
-						Value:   ".env",
-					},
-					&cli.StringFlag{
-						Name:     "namespace",
-						Aliases:  []string{"n"},
-						Usage:    "Kube Namespace list Pods from",
-						Required: true,
-					},
-					&cli.StringFlag{
-						Name:     "dotenv",
-						Usage:    "Path to .env file on Pod",
-						Required: false,
-						Value:    "$PWD/.env",
-					},
-				},
-				Action: cmd.ViewAnsibleEnvDiff,
-			},
-			{
-				Name:    "local",
-				Aliases: []string{"l"},
-				Usage:   "Interact with local env files",
+				Name: "env",
+				Aliases: []string{"e"},
+				Usage: "Commands to interact with environment variables, both local and on cluster.",
+				// TODO: add UsageText
+				UsageText: "TODO",
 				Subcommands: []*cli.Command{
+					{
+						Name:      "diff",
+						Aliases:   []string{"d"},
+						Usage: "Print out detailed diff reports comparing local and running Pod",
+						// TODO: add UsageText
+						Subcommands: []*cli.Command{
+							{
+								Name:      "namespace",
+								Aliases:   []string{"ns"},
+								Usage:     "View diff of local vs. namespace",
+								UsageText: info.ViewDiffCommandHelpText,
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "secrets",
+										Aliases:  []string{"s"},
+										Usage:    "Path to secrets.yml",
+										Required: false,
+										Value:    ".docker/secrets.yml",
+									},
+									&cli.StringFlag{
+										Name:     "configmap",
+										Aliases:  []string{"c"},
+										Usage:    "Path to configmap.yaml",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "namespace",
+										Aliases:  []string{"n"},
+										Usage:    "Kube Namespace to list Pods from for inspection",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "cmd",
+										Usage:    "Command to inspect",
+										Required: false,
+										Value:    "node",
+									},
+									&cli.StringFlag{
+										Name:     "filter-prefix",
+										Aliases:  []string{"f"},
+										Usage:    "List of prefixes (csv) used to filter values from display. Set to \"\" to remove any filters.",
+										Required: false,
+										Value:    "npm_,KUBERNETES_,API_PORT",
+									},
+									&cli.StringFlag{
+										Name:     "exclude",
+										Usage:    "List (csv) of specific env vars to exclude values from display. Set to \"\" to remove any exclusions.",
+										Required: false,
+										Value:    "PATH,SHLVL,HOSTNAME",
+									},
+									&cli.StringFlag{
+										Name:  "secret-suffix",
+										Usage: "Suffix used to find ENV variables that denote the Secret Manager Secrets to lookup",
+										Value: "_NAME",
+									},
+								},
+								Action: cmd.ViewEnvDiff,
+							},
+							{
+								Name:      "ansible",
+								Aliases:   []string{"legacy"},
+								Usage:     "View diff of local (ansible encrypted) vs. namespace",
+								UsageText: info.ViewAnsibleEnvDiffCommandHelpText,
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "vault-password-file",
+										Usage:    "vault password file `VAULT_PASSWORD_FILE`",
+										Required: false,
+									},
+									&cli.StringFlag{
+										Name:     "encrypted-env-file",
+										Aliases:  []string{"e"},
+										Usage:    "Path to encrypted Kube Secret file",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:    "accessor",
+										Aliases: []string{"a"},
+										Usage:   "Accessor key to pull data out of Data block.",
+										Value:   ".env",
+									},
+									&cli.StringFlag{
+										Name:     "namespace",
+										Aliases:  []string{"n"},
+										Usage:    "Kube Namespace list Pods from for inspection",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "dotenv",
+										Usage:    "Path to .env file on Pod",
+										Required: false,
+										Value:    "$PWD/.env",
+									},
+								},
+								Action: cmd.ViewAnsibleEnvDiff,
+							},
+						},
+					},
 					{
 						Name:      "view",
 						Aliases:   []string{"v"},
-						Usage:     "View values based on local settings",
-						UsageText: info.ViewLocalCommandHelpText,
-						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "secrets",
-								Aliases:  []string{"s"},
-								Usage:    "Path to secrets.yml",
-								Required: false,
-								Value:    ".docker/secrets.yml",
+						Usage:   "View configured environment for either local or running on a Pod",
+						// TODO: add UsageText
+						Subcommands: []*cli.Command{
+							{
+								Name:      "configmap",
+								Aliases:   []string{"c"},
+								Usage:     "View values based on local settings",
+								UsageText: info.ViewLocalCommandHelpText,
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "secrets",
+										Aliases:  []string{"s"},
+										Usage:    "Path to secrets.yml",
+										Required: false,
+										Value:    ".docker/secrets.yml",
+									},
+									&cli.StringFlag{
+										Name:     "configmap",
+										Aliases:  []string{"c"},
+										Usage:    "Path to configmap.yaml",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:  "secret-suffix",
+										Usage: "Suffix used to find ENV variables that denote the Secret Manager Secrets to lookup",
+										Value: "_NAME",
+									},
+								},
+								Action: cmd.ViewLocalEnv,
 							},
-							&cli.StringFlag{
-								Name:     "configmap",
-								Aliases:  []string{"c"},
-								Usage:    "Path to configmap.yaml",
-								Required: true,
+							{
+								Name:      "ansible",
+								Aliases:   []string{"legacy"},
+								Usage:     "View value from ansible-vault encrypted Kube Secret file.",
+								UsageText: info.ViewAnsibleEncryptedEnvCommandHelpText,
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "vault-password-file",
+										Usage:    "vault password file `VAULT_PASSWORD_FILE`",
+										Required: false,
+									},
+									&cli.StringFlag{
+										Name:     "encrypted-env-file",
+										Aliases:  []string{"e"},
+										Usage:    "Path to encrypted Kube Secret file",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:    "accessor",
+										Aliases: []string{"a"},
+										Usage:   "Accessor key to pull data out of Data block.",
+										Value:   ".env",
+									},
+								},
+								Action: cmd.ViewAnsibleEncryptedEnv,
 							},
-							&cli.StringFlag{
-								Name:  "secret-suffix",
-								Usage: "Suffix used to find ENV variables that denote the Secret Manager Secrets to lookup",
-								Value: "_NAME",
+							{
+								Name:      "namespace",
+								Aliases:   []string{"ns"},
+								Usage:     "Interact with env on a running Pod within a Namespace",
+								UsageText: info.ViewNamespaceCommandHelpText,
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "namespace",
+										Aliases:  []string{"n"},
+										Usage:    "Kube Namespace list Pods from",
+										Required: true,
+									},
+									&cli.StringFlag{
+										Name:     "cmd",
+										Usage:    "Command to inspect",
+										Required: false,
+										Value:    "node",
+									},
+									&cli.StringFlag{
+										Name:     "filter-prefix",
+										Aliases:  []string{"f"},
+										Usage:    "List of prefixes (csv) used to filter values from display. Set to \"\" to remove any filters.",
+										Required: false,
+										Value:    "npm_,KUBERNETES_,API_PORT",
+									},
+									&cli.StringFlag{
+										Name:     "exclude",
+										Usage:    "List (csv) of specific env vars to exclude values from display. Set to \"\" to remove any exclusions.",
+										Required: false,
+										Value:    "PATH,SHLVL,HOSTNAME",
+									},
+								},
+								Action: cmd.ViewNamespaceEnv,
 							},
 						},
-						Action: cmd.ViewLocalEnv,
-					},
-					{
-						Name:      "ansible",
-						Aliases:   []string{"legacy", "a"},
-						Usage:     "View value from ansible-vault encrypted Kube Secret file.",
-						UsageText: info.ViewAnsibleEncryptedEnvCommandHelpText,
-						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "vault-password-file",
-								Usage:    "vault password file `VAULT_PASSWORD_FILE`",
-								Required: false,
-							},
-							&cli.StringFlag{
-								Name:     "encrypted-env-file",
-								Aliases:  []string{"e"},
-								Usage:    "Path to encrypted Kube Secret file",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:    "accessor",
-								Aliases: []string{"a"},
-								Usage:   "Accessor key to pull data out of Data block.",
-								Value:   ".env",
-							},
-						},
-						Action: cmd.ViewAnsibleEncryptedEnv,
-					},
-				},
-			},
-			{
-				Name:    "namespace",
-				Aliases: []string{"ns"},
-				Usage:   "Interact with env on a running Pod within a Namespace",
-				Subcommands: []*cli.Command{
-					{
-						Name:      "view",
-						Aliases:   []string{"v"},
-						Usage:     "View values configured within a namespace",
-						UsageText: info.ViewNamespaceCommandHelpText,
-						Flags: []cli.Flag{
-							&cli.StringFlag{
-								Name:     "namespace",
-								Aliases:  []string{"n"},
-								Usage:    "Kube Namespace list Pods from",
-								Required: true,
-							},
-							&cli.StringFlag{
-								Name:     "cmd",
-								Usage:    "Command to inspect",
-								Required: false,
-								Value:    "node",
-							},
-							&cli.StringFlag{
-								Name:     "filter-prefix",
-								Aliases:  []string{"f"},
-								Usage:    "List of prefixes (csv) used to filter values from display. Set to \"\" to remove any filters.",
-								Required: false,
-								Value:    "npm_,KUBERNETES_,API_PORT",
-							},
-							&cli.StringFlag{
-								Name:     "exclude",
-								Usage:    "List (csv) of specific env vars to exclude values from display. Set to \"\" to remove any exclusions.",
-								Required: false,
-								Value:    "PATH,SHLVL,HOSTNAME",
-							},
-						},
-						Action: cmd.ViewNamespaceEnv,
 					},
 				},
 			},
@@ -389,24 +402,23 @@ func main() {
 				},
 			},
 			{
-				Name:    "version",
-				Aliases: []string{"v"},
-				Usage:   "Print version info",
-				Action: func(c *cli.Context) error {
-					fmt.Printf("%s %s (%s/%s)\n", info.AppName, version, runtime.GOOS, runtime.GOARCH)
-					return nil
-				},
-			},
-			{
 				Name:   "install-manpage",
-				Usage:  "Generate and install manpage",
-				Hidden: true,
+				Usage:  "Generate and install man page",
 				Action: func(c *cli.Context) error {
 					mp, _ := info.ToMan(c.App)
 					err := ioutil.WriteFile("/usr/local/share/man/man8/gwsm.8", []byte(mp), 0644)
 					if err != nil {
 						return cli.NewExitError(fmt.Sprintf("Unable to install man page: %e", err), 2)
 					}
+					return nil
+				},
+			},
+			{
+				Name:    "version",
+				Aliases: []string{"v"},
+				Usage:   "Print version info",
+				Action: func(c *cli.Context) error {
+					fmt.Printf("%s %s (%s/%s)\n", info.AppName, version, runtime.GOOS, runtime.GOARCH)
 					return nil
 				},
 			},


### PR DESCRIPTION
### Old command tree

- secretsmanager, sm
    - list
    - describe
    - get, view
    - edit, e
    - create, c
    - put
    - delete, del
- diff, d
- diff:legacy, diff:ansible
- local, l
    - view, v
    - ansible, legacy, a
- namespace, ns
    - view, v
- s3
    - get
- version, v

### New command tree

- sm, secretsmanager
    - list
    - describe
    - get, view
    - edit, e
    - create, c
    - put
    - delete, del
- env, e
    - diff, d
        - namespace, ns
        - ansible, legacy
    - view, v
        - configmap, c
        - ansible, legacy
        - namespace, ns
- s3
    - get
- install-manpage
- version, v