### PR TITLE
feat(sm): added support description and tags on creation, added put sub command

### DIFF
--- a/cmd/sm.go
+++ b/cmd/sm.go
@@ -312,10 +312,10 @@ func CreateSecret(c *cli.Context) error {
 	var t string
 	if c.Bool("binary") {
 		t = "BinarySecret"
-		_, err = sm.CreateSecretBinary(secretName, s)
+		_, err = sm.CreateSecretBinary(secretName, s, c.String("description"))
 	} else {
 		t = "StringSecret"
-		_, err = sm.CreateSecretString(secretName, string(s))
+		_, err = sm.CreateSecretString(secretName, string(s), c.String("description"))
 	}
 
 	if err != nil {

--- a/cmd/sm.go
+++ b/cmd/sm.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-// Limit the length of a string while also appending an ellipses.
+// truncateString limits the length of a string while also appending an ellipses.
 func truncateString(str string, num int) string {
 	short := str
 	if len(str) > num {
@@ -27,9 +27,9 @@ func truncateString(str string, num int) string {
 	return short
 }
 
-// Helper method to either bypass and return the `secretName` passed in via CLI
-// flag OR retrieve a list of all secrets to allow for a search select by the
-// User.
+// selectSecretNameFromList is a helper method to either bypass and return the
+// `secretName` passed in via CLI flag OR retrieve a list of all secrets to allow
+// for a search select by the User.
 func selectSecretNameFromList(c *cli.Context) (string, error) {
 	secretName := c.String("secret-id")
 	if secretName == "" {
@@ -60,6 +60,7 @@ func selectSecretNameFromList(c *cli.Context) (string, error) {
 	return secretName, nil
 }
 
+// promptForEdit is a helper method providing an editor interface.
 func promptForEdit(secretName string, s []byte) ([]byte, error) {
 	ed := ""
 	prompt := &survey.Editor{
@@ -77,7 +78,8 @@ func promptForEdit(secretName string, s []byte) ([]byte, error) {
 	return []byte(ed), nil
 }
 
-func SMListSecrets(c *cli.Context) error {
+// ListSecrets CLI command to list all Secrets.
+func ListSecrets(c *cli.Context) error {
 	secrets, err := sm.ListSecrets()
 	if err != nil {
 		return cli.NewExitError(err, 2)
@@ -116,7 +118,8 @@ func SMListSecrets(c *cli.Context) error {
 	return nil
 }
 
-func SMViewSecret(c *cli.Context) error {
+// ViewSecret CLI command to view/get a Secret.
+func ViewSecret(c *cli.Context) error {
 	secretName, err := selectSecretNameFromList(c)
 	if err != nil {
 		return cli.NewExitError(err, 2)
@@ -146,7 +149,8 @@ func SMViewSecret(c *cli.Context) error {
 	return nil
 }
 
-func SMDescribeSecret(c *cli.Context) error {
+// DescribeSecret CLI command to describe a Secret.
+func DescribeSecret(c *cli.Context) error {
 	secretName, err := selectSecretNameFromList(c)
 	if err != nil {
 		return cli.NewExitError(err, 2)
@@ -162,7 +166,8 @@ func SMDescribeSecret(c *cli.Context) error {
 	return nil
 }
 
-func SMEditSecret(c *cli.Context) error {
+// EditSecret CLI command to edit a Secret.
+func EditSecret(c *cli.Context) error {
 	secretName, err := selectSecretNameFromList(c)
 	if err != nil {
 		return cli.NewExitError(err, 2)
@@ -259,7 +264,8 @@ func SMEditSecret(c *cli.Context) error {
 	return nil
 }
 
-func SMCreateSecret(c *cli.Context) error {
+// CreateSecret CLI command to create a new Secret.
+func CreateSecret(c *cli.Context) error {
 	secretName := c.String("secret-id")
 	exists, err := sm.CheckIfSecretExists(secretName)
 	if err != nil {
@@ -321,7 +327,9 @@ func SMCreateSecret(c *cli.Context) error {
 	return nil
 }
 
-func SMPutSecret(c *cli.Context) error {
+// PutSecret CLI command to apply a delta to a Secret.
+// TODO: PutSecret Not yet implemented
+func PutSecret(c *cli.Context) error {
 	secretName := c.String("secret-id")
 	exists, err := sm.CheckIfSecretExists(secretName)
 	if err != nil {
@@ -336,7 +344,8 @@ func SMPutSecret(c *cli.Context) error {
 	return cli.NewExitError("Not yet implemented", 5)
 }
 
-func SMDeleteSecret(c *cli.Context) error {
+// DeleteSecret CLI command that will delete a Secret.
+func DeleteSecret(c *cli.Context) error {
 	secretName := c.String("secret-id")
 	exists, err := sm.CheckIfSecretExists(secretName)
 	if err != nil {

--- a/cmd/sm.go
+++ b/cmd/sm.go
@@ -312,10 +312,10 @@ func CreateSecret(c *cli.Context) error {
 	var t string
 	if c.Bool("binary") {
 		t = "BinarySecret"
-		_, err = sm.CreateSecretBinary(secretName, s, c.String("description"))
+		_, err = sm.CreateSecretBinary(secretName, s, c.String("description"), c.String("tags"))
 	} else {
 		t = "StringSecret"
-		_, err = sm.CreateSecretString(secretName, string(s), c.String("description"))
+		_, err = sm.CreateSecretString(secretName, string(s), c.String("description"), c.String("tags"))
 	}
 
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AlecAivazis/survey/v2 v2.1.1 h1:LEMbHE0pLj75faaVEKClEX1TM4AJmmnOh9eimREzLWI=
-github.com/AlecAivazis/survey/v2 v2.1.1/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
 github.com/AlecAivazis/survey/v2 v2.2.2 h1:1I4qBrNsHQE+91tQCqVlfrKe9DEL65949d1oKZWVELY=
 github.com/AlecAivazis/survey/v2 v2.2.2/go.mod h1:9FJRdMdDm8rnT+zHVbvQT2RTSTLq0Ttd6q3Vl2fahjk=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -38,8 +36,6 @@ github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2/go.mod h1:VSw
 github.com/a8m/djson v0.0.0-20170509170705-c02c5aef757f h1:su5fhWd5UCmmRQEFPQPalJ304Qtcgk9ZDDnKnvpsraU=
 github.com/a8m/djson v0.0.0-20170509170705-c02c5aef757f/go.mod h1:w3s8fnedJo6LJQ7dUUf1OcetqgS1hGpIDjY5bBowg1Y=
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/aws/aws-sdk-go v1.35.17 h1:zhahppAMdPvJ9GP302SMOPW5SNoAbnjdOyaTmxA9WJU=
-github.com/aws/aws-sdk-go v1.35.17/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.35.27 h1:F0dUW+kouzchjt4X6kYfYMw1YtQPkA4pihpCDqQMrq8=
 github.com/aws/aws-sdk-go v1.35.27/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -257,8 +253,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 						// list-secrets
 						Name:   "list",
 						Usage:  "display table of all secrets with meta data",
-						Action: cmd.SMListSecrets,
+						Action: cmd.ListSecrets,
 					},
 					{
 						// describe-secret
@@ -71,7 +71,7 @@ func main() {
 								Usage:   "Specific Secret to describe, will bypass select/search",
 							},
 						},
-						Action: cmd.SMDescribeSecret,
+						Action: cmd.DescribeSecret,
 					},
 					{
 						// get-secret-value
@@ -85,7 +85,7 @@ func main() {
 								Usage:   "Specific Secret to view, will bypass select/search",
 							},
 						},
-						Action: cmd.SMViewSecret,
+						Action: cmd.ViewSecret,
 					},
 					{
 						Name:    "edit",
@@ -99,7 +99,7 @@ func main() {
 								Usage:   "Specific Secret to edit, will bypass select/search",
 							},
 						},
-						Action: cmd.SMEditSecret,
+						Action: cmd.EditSecret,
 					},
 					{
 						// create-secret
@@ -136,7 +136,7 @@ func main() {
 								Usage: "key=value tags (CSV list)",
 							},
 						},
-						Action: cmd.SMCreateSecret,
+						Action: cmd.CreateSecret,
 					},
 					{
 						// put-secret-value
@@ -172,7 +172,7 @@ func main() {
 							},
 						},
 						// TODO: Flag for use of binary
-						Action: cmd.SMPutSecret,
+						Action: cmd.PutSecret,
 					},
 					{
 						Name:    "delete",
@@ -191,7 +191,7 @@ func main() {
 								Usage:   "Bypass recovery window (30 days) and immediately delete Secret.",
 							},
 						},
-						Action: cmd.SMDeleteSecret,
+						Action: cmd.DeleteSecret,
 					},
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 								Aliases: []string{"s"},
 								Usage:   "Specific Secret to edit, will bypass select/search",
 							},
+							// TODO: add flag for passing version stage
 						},
 						Action: cmd.EditSecret,
 					},
@@ -141,6 +142,14 @@ func main() {
 						// put-secret-value
 						Name:  "put",
 						Usage: "non-interactive update to a specific secret",
+						UsageText: `
+Stores a new encrypted secret value in the specified secret. To do this, the 
+operation creates a new version and attaches it to the secret. The version 
+can contain a new SecretString value or a new SecretBinary value.
+
+This will put the value to AWSCURRENT and retain one previous version 
+with AWSPREVIOUS.
+`,
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "secret-id",
@@ -156,20 +165,10 @@ func main() {
 							&cli.BoolFlag{
 								Name:    "interactive",
 								Aliases: []string{"i"},
-								Usage:   "Open interactive editor to create secret value.",
+								Usage:   "Override and open interactive editor to verify and modify the new secret value.",
 							},
-							&cli.StringFlag{
-								Name:    "description",
-								Aliases: []string{"d"},
-								Usage:   "Additional description text.",
-							},
-							&cli.StringFlag{
-								Name:    "tags",
-								Aliases: []string{"t"},
-								Usage:   "key=value tags (CSV list)",
-							},
+							// TODO: add flag for passing version stage
 						},
-						// TODO: Flag for use of binary
 						Action: cmd.PutSecret,
 					},
 					{

--- a/main.go
+++ b/main.go
@@ -122,12 +122,11 @@ func main() {
 							&cli.BoolFlag{
 								Name:    "interactive",
 								Aliases: []string{"i"},
-								Usage:   "Open interactive editor to create secret value.",
+								Usage:   "Open interactive editor to create secret value. If no 'value' is provided, an editor will be opened by default.",
 							},
 							&cli.StringFlag{
-								// TODO: add description feature
 								Name:    "description",
-								Aliases: []string{"desc"},
+								Aliases: []string{"desc", "d"},
 								Usage:   "Additional description text.",
 							},
 							&cli.StringFlag{
@@ -160,9 +159,8 @@ func main() {
 								Usage:   "Open interactive editor to create secret value.",
 							},
 							&cli.StringFlag{
-								// TODO: add description feature
 								Name:    "description",
-								Aliases: []string{"desc"},
+								Aliases: []string{"desc", "d"},
 								Usage:   "Additional description text.",
 							},
 							&cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -126,13 +126,13 @@ func main() {
 							},
 							&cli.StringFlag{
 								Name:    "description",
-								Aliases: []string{"desc", "d"},
+								Aliases: []string{"d"},
 								Usage:   "Additional description text.",
 							},
 							&cli.StringFlag{
-								// TODO: add tags feature
-								Name:  "tags",
-								Usage: "key=value tags (CSV list)",
+								Name:    "tags",
+								Aliases: []string{"t"},
+								Usage:   "key=value tags (CSV list)",
 							},
 						},
 						Action: cmd.CreateSecret,
@@ -160,13 +160,13 @@ func main() {
 							},
 							&cli.StringFlag{
 								Name:    "description",
-								Aliases: []string{"desc", "d"},
+								Aliases: []string{"d"},
 								Usage:   "Additional description text.",
 							},
 							&cli.StringFlag{
-								// TODO: add tags feature
-								Name:  "tags",
-								Usage: "key=value tags (CSV list)",
+								Name:    "tags",
+								Aliases: []string{"t"},
+								Usage:   "key=value tags (CSV list)",
 							},
 						},
 						// TODO: Flag for use of binary

--- a/sm/main.go
+++ b/sm/main.go
@@ -185,17 +185,23 @@ func PutSecretBinary(id string, data []byte) (secret *secretsmanager.PutSecretVa
 }
 
 // CreateSecretString will create a new SecretString value to a specific secret by Name (id)
-func CreateSecretString(id string, data string) (secret *secretsmanager.CreateSecretOutput, err error) {
+func CreateSecretString(id string, data string, description string) (secret *secretsmanager.CreateSecretOutput, err error) {
 	sess, err := as.New()
 	if err != nil {
 		return nil, err
 	}
 	svc := secretsmanager.New(sess)
 
-	secret, err = svc.CreateSecret(&secretsmanager.CreateSecretInput{
+	input := secretsmanager.CreateSecretInput{
 		SecretString: aws.String(data),
 		Name:         aws.String(id),
-	})
+	}
+
+	if description != "" {
+		input.Description = aws.String(description)
+	}
+
+	secret, err = svc.CreateSecret(&input)
 
 	if err != nil {
 		return nil, err
@@ -205,17 +211,23 @@ func CreateSecretString(id string, data string) (secret *secretsmanager.CreateSe
 }
 
 // CreateSecretBinary will create a new SecretBinary value to a specific secret by Name (id)
-func CreateSecretBinary(id string, data []byte) (secret *secretsmanager.CreateSecretOutput, err error) {
+func CreateSecretBinary(id string, data []byte, description string) (secret *secretsmanager.CreateSecretOutput, err error) {
 	sess, err := as.New()
 	if err != nil {
 		return nil, err
 	}
 	svc := secretsmanager.New(sess)
 
-	secret, err = svc.CreateSecret(&secretsmanager.CreateSecretInput{
+	input := secretsmanager.CreateSecretInput{
 		SecretBinary: data,
 		Name:         aws.String(id),
-	})
+	}
+
+	if description != "" {
+		input.Description = aws.String(description)
+	}
+
+	secret, err = svc.CreateSecret(&input)
 
 	if err != nil {
 		return nil, err

--- a/sm/main.go
+++ b/sm/main.go
@@ -185,7 +185,7 @@ func PutSecretBinary(id string, data []byte) (secret *secretsmanager.PutSecretVa
 }
 
 // CreateSecretString will create a new SecretString value to a specific secret by Name (id)
-func CreateSecretString(id string, data string, description string) (secret *secretsmanager.CreateSecretOutput, err error) {
+func CreateSecretString(id string, data string, description string, tagsCSV string) (secret *secretsmanager.CreateSecretOutput, err error) {
 	sess, err := as.New()
 	if err != nil {
 		return nil, err
@@ -201,6 +201,18 @@ func CreateSecretString(id string, data string, description string) (secret *sec
 		input.Description = aws.String(description)
 	}
 
+	if tagsCSV != "" {
+		var tags []*secretsmanager.Tag
+		for _, kv := range strings.Split(tagsCSV, ",") {
+			parts := strings.SplitN(kv, "=", 2)
+			tags = append(tags, &secretsmanager.Tag{
+				Key:   aws.String(parts[0]),
+				Value: aws.String(parts[1]),
+			})
+		}
+		input.Tags = tags
+	}
+
 	secret, err = svc.CreateSecret(&input)
 
 	if err != nil {
@@ -211,7 +223,7 @@ func CreateSecretString(id string, data string, description string) (secret *sec
 }
 
 // CreateSecretBinary will create a new SecretBinary value to a specific secret by Name (id)
-func CreateSecretBinary(id string, data []byte, description string) (secret *secretsmanager.CreateSecretOutput, err error) {
+func CreateSecretBinary(id string, data []byte, description string, tagsCSV string) (secret *secretsmanager.CreateSecretOutput, err error) {
 	sess, err := as.New()
 	if err != nil {
 		return nil, err
@@ -225,6 +237,18 @@ func CreateSecretBinary(id string, data []byte, description string) (secret *sec
 
 	if description != "" {
 		input.Description = aws.String(description)
+	}
+
+	if tagsCSV != "" {
+		var tags []*secretsmanager.Tag
+		for _, kv := range strings.Split(tagsCSV, ",") {
+			parts := strings.SplitN(kv, "=", 2)
+			tags = append(tags, &secretsmanager.Tag{
+				Key:   aws.String(parts[0]),
+				Value: aws.String(parts[1]),
+			})
+		}
+		input.Tags = tags
 	}
 
 	secret, err = svc.CreateSecret(&input)


### PR DESCRIPTION
- chore(sm): update comments and clean up naming
- feat(sm): added support for passing the description on creation
- feat(sm): added support for passing the tags on creation
- feat(sm): add put sub-command functionality

This feature adds support to pass a Description and a CSV list of Tags via CLI flags on the `sm create` command.

```
$ gwsm sm create -s dsmith/test5 -v '{"a":"b"}' -d "This is a test." --tags test=1,env=prod,dumb=p=1=2
✔ clok/test5 StringSecret successfully created.
```

```
$ gwsm sm describe -s clok/test5
{
  ARN: "arn:aws:secretsmanager:us-east-1:1234123231312:secret:clok/test5-nBLIxR",
  CreatedDate: 2020-11-13 05:10:58.77 +0000 UTC,
  Description: "This is a test.",
  LastChangedDate: 2020-11-13 05:10:58.838 +0000 UTC,
  Name: "clok/test5",
  Tags: [{
      Key: "dumb",
      Value: "p=1=2"
    },{
      Key: "test",
      Value: "1"
    },{
      Key: "env",
      Value: "prod"
    }],
  VersionIdsToStages: {
    BBF76859-0644-46F9-8F1D-7A147CDF8713: ["AWSCURRENT"]
  }
}
```

Also, the `gwsm sm put` command is now implemented.